### PR TITLE
refactoring: byValue, byAny, byProp

### DIFF
--- a/src/sortables/byAny.ts
+++ b/src/sortables/byAny.ts
@@ -1,16 +1,17 @@
 import { sortable } from "../types/types";
 import { SortOption } from "../interfaces/interfaces";
 import { byDate, byNumber, byString } from "../index";
+import { isNumber, isString, isDate } from '../tools';
 
-const byAny = <T>(options: SortOption = { desc: false }): sortable<T> => {
+const byAny = <T extends string | number | Date>(options: SortOption = { desc: false }): sortable<T> => {
   return (first: T, second: T): number => {
-    if (typeof first === "number" && typeof second === "number")
+    if (isNumber(first) && isNumber(second))
       return byNumber(options)(first, second);
 
-    if (typeof first === "string" && typeof second === "string")
+    if (isString(first) && isString(second))
       return byString(options)(first, second);
 
-    if (first instanceof Date && second instanceof Date)
+    if (isDate(first) && isDate(second))
       return byDate(options)(first, second);
 
     throw new Error("incorrect types of the 2 parameters");

--- a/src/sortables/byProp.ts
+++ b/src/sortables/byProp.ts
@@ -1,0 +1,15 @@
+import { sortable } from '../types/types';
+
+const byProp = <T, K extends keyof T>(
+  prop: K,
+  sortFn: sortable<T[K]>
+): sortable<T> => {
+  return (first: T, second: T): number => {
+    const firstItem: T[K] = first[prop];
+    const secondItem: T[K] = second[prop];
+
+    return sortFn(firstItem, secondItem);
+  };
+}
+
+export default byProp;

--- a/src/sortables/byValue.ts
+++ b/src/sortables/byValue.ts
@@ -1,22 +1,12 @@
 import { sortable } from "../types/types";
 
-const getValueByDiscriminator = <T, K extends keyof T>(
-  obj: T,
-  discriminator: K | ((item: T) => T[K])
-): T[K] => {
-  return typeof discriminator === "function"
-    ? discriminator(obj)
-    : obj[discriminator];
-};
-
-const byValue = <T, K extends keyof T>(
-  discriminator: K | ((item: T) => T[K]),
-  sortFn: sortable<T[K]>
+const byValue = <T, V>(
+  valueFn: (item: T) => V,
+  sortFn: sortable<V>
 ): sortable<T> => {
   return (first: T, second: T): number => {
-    const firstItem: T[K] = getValueByDiscriminator(first, discriminator);
-
-    const secondItem: T[K] = getValueByDiscriminator(second, discriminator);
+    const firstItem: V = valueFn(first);
+    const secondItem: V = valueFn(second);
 
     return sortFn(firstItem, secondItem);
   };


### PR DESCRIPTION
# Notes

I have a few comments to make. I would be glad if they are heard. I like the project, but because of these comments it is not very convenient to use it in work.


## `byAny`

The sorter code is like this:

```ts
const byAny = <T>(options: SortOption = { desc: false }): sortable<T> => {
  return (first: T, second: T): number => {
    if (typeof first === "number" && typeof second === "number")
      return byNumber(options)(first, second);

    if (typeof first === "string" && typeof second === "string")
      return byString(options)(first, second);

    if (first instanceof Date && second instanceof Date)
      return byDate(options)(first, second);

    throw new Error("incorrect types of the 2 parameters");
  };
};
```

As you can see, it sorts anything by type, but fails with an error if `T` is not `number | string | Date`. So why not do this type-level protection while also making the function truly 'type-safe'?

```ts
function isNumber(v: unknown): v is number {
  return typeof v === "number";
}

function isString(v: unknown): v is string {
  return typeof v === "string";
}

function isDate(v: unknown): v is Date {
  return v instanceof Date;
}

const byAny = <T extends string | number | Date>(options: SortOption = { desc: false }): sortable<T> => {
  return (first: T, second: T): number => {
    if (isNumber(first) && isNumber(second))
      return byNumber(options)(first, second);

    if (isString(first) && isString(second))
      return byString(options)(first, second);

    if (isDate(first) && isDate(second))
      return byDate(options)(first, second);

    throw new Error("incorrect types of the 2 parameters");
  };
};
```

## `byValue`

The `byValue` sorter is not very flexible in its typing. As I see it, his idea is to provide a custom function to extract some value from a list item for use in sorting. However, in the `byValue` typing there is something like this:

```ts
const byValue = <T, K extends keyof T>(
  discriminator: K | ((item: T) => T[K]),
  sortFn: sortable<T[K]>
): sortable<T> => {
  return (first: T, second: T): number => {
    const firstItem: T[K] = getValueByDiscriminator(first, discriminator);

    const secondItem: T[K] = getValueByDiscriminator(second, discriminator);

    return sortFn(firstItem, secondItem);
  };
};
```

It is clearly shown here that byValue only works with values ​​from the root elements of the list, which is by no means a flexible solution.

Let's say there is an array like this:

```ts
const items: { value: number }[] = [{ value: 5 }, { value: 1 }];
```

```ts
items.sort(byValue('value', byNumber())); // ok!

items.sort(byValue((x) => x.value, byNumber()); // ok!

items.sort(byValue((x) => x.value * x.value, byNumber())); // ok!

items.sort(byValue((x) => `${x.value}`, byString())); // ERROR!
// Argument of type '(x: { value: number; }) => string' is not assignable to parameter of type '"value" | ((item: { value: number; }) => number)'.
//   Type '(x: { value: number; }) => string' is not assignable to type '(item: { value: number; }) => number'.
//     Type 'string' is not assignable to type 'number'
```

Why is there a mistake? Because the discriminator function must return `T [K]`, where `T` - `{value: number} `, `K` - `'value'`, and `T[K]` - `number`. Why should I necessarily be limited to types in the original object when fetching data?

I made a more flexible option:

```ts
const byValue = <T, V>(
  valueFn: (item: T) => V,
  sortFn: sortable<V>
): sortable<T> => {
  return (first: T, second: T): number => {
    const firstItem: V = valueFn(first);
    const secondItem: V = valueFn(second);

    return sortFn(firstItem, secondItem);
  };
};
```

Here you can retrieve any data you want, based (or not based) on the elements of the array. It is possible, for example, to draw up some kind of data map for the original array, in which some data on the array elements will be pre-calculated, and which can be accessed so as not to burden the sorting with constant calculations. There are many things you can do.

## `byProp`

The feature of the old `byValue` is lost - you cannot just pass the name of the object field to sort by it. For this I made a separate sorter, `byProp`:

```ts
const byProp = <T, K extends keyof T>(
  prop: K,
  sortFn: sortable<T[K]>
): sortable<T> => {
  return (first: T, second: T): number => {
    const firstItem: T[K] = first[prop];
    const secondItem: T[K] = second[prop];

    return sortFn(firstItem, secondItem);
  };
}
```

Migration:

- Wherever sorting by key is used, for example `arr.sort (byValue ('prop', byNumber ()))`, you must replace `byValue` with` byProp`.

