### PR TITLE
Changed how byNumber handles NaN, etc.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.32.2",
+    "fast-check": "^3.13.1",
     "husky": "^8.0.3",
     "mocha": "^10.2.0",
     "nyc": "^15.1.0",

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -1,19 +1,51 @@
 import { datable } from "../types/types";
 
-interface SortOption {
+export interface SortOption {
   desc?: boolean;
   nullable?: boolean;
 }
 
-interface SortByNumberOption extends SortOption {
+/**
+ * The default value of {@link SortByNumberOption.valuesOrder}.
+ */
+export const DEFAULT_NUMBER_VALUE_CATEGORY_ORDER = [
+    "other",
+    "NaN",
+    "null",
+    "undefined",
+] as const;
+
+/**
+ * A kind of value that can be sorted using `byNumber`.
+ */
+export type NumberValueCategory = (typeof DEFAULT_NUMBER_VALUE_CATEGORY_ORDER)[number];
+
+/**
+ * Sorting options for `byNumber`.
+ */
+export interface SortByNumberOption extends SortOption {
   /**
-   * This option controls how NaN values are sorted:
+   * This option controls how various special values are sorted relative to one
+   * another.
    *
-   * - "first" or undefined: NaN is sorted before any other value.
-   * - "last": NaN is sorted after any other value.
-   * - "error": Any comparison involving NaN throws an error.
+   * Each possible value may appear at most once. The default order is ["other",
+   * "NaN", "null", "undefined"], meaning ordinary numbers are sortered first,
+   * followed by any `NaN`, then all `null` values, and finally all `undefined`
+   * values.
+   *
+   * Omitting "other" is the same as putting it first.  Omitting any of "NaN",
+   * "null", or "undefined" is the same as putting that value last; omitting
+   * more than one is the same as putting the last in the same order as in the
+   * default array.
+   *
+   * The {@link SortOption.desc} does not affect the order created by this
+   * option. It only affects how numbers are sorted within the "others"
+   * category.
+   *
+   * Note that `Array.sort` always acts as if "undefined" is last, regardless of
+   * any sorting options.
    */
-  sortNaN?: "first" | "last" | "error";
+    valueCategoryOrder?: NumberValueCategory[];
 
   /**
    * @deprecated Using this option results in a comparison function that is
@@ -25,12 +57,10 @@ interface SortByNumberOption extends SortOption {
   nullable?: boolean;
 }
 
-interface SortByStringOption extends SortOption {
+export interface SortByStringOption extends SortOption {
   lowercase?: boolean;
 }
 
-interface SortByDateOption extends SortOption {
+export interface SortByDateOption extends SortOption {
   customParser?: (item: datable) => Date;
 }
-
-export { SortOption, SortByNumberOption, SortByStringOption, SortByDateOption };

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -5,6 +5,26 @@ interface SortOption {
   nullable?: boolean;
 }
 
+interface SortByNumberOption extends SortOption {
+  /**
+   * This option controls how NaN values are sorted:
+   *
+   * - "first" or undefined: NaN is sorted before any other value.
+   * - "last": NaN is sorted after any other value.
+   * - "error": Any comparison involving NaN throws an error.
+   */
+  sortNaN?: "first" | "last" | "error";
+
+  /**
+   * @deprecated Using this option results in a comparison function that is
+   * inconistent with the behavior of `Array.prototype.sort`, which always sorts
+   * `undefined` to the end of the array regardless of the comparison function.
+   * Futhermore, this option is not useful for controlling the sorting of
+   * `null`, because `byNumber` always treats `null` as equal to 0.
+   */
+  nullable?: boolean;
+}
+
 interface SortByStringOption extends SortOption {
   lowercase?: boolean;
 }
@@ -13,4 +33,4 @@ interface SortByDateOption extends SortOption {
   customParser?: (item: datable) => Date;
 }
 
-export { SortOption, SortByStringOption, SortByDateOption };
+export { SortOption, SortByNumberOption, SortByStringOption, SortByDateOption };

--- a/src/sortables/byNumber.ts
+++ b/src/sortables/byNumber.ts
@@ -1,5 +1,5 @@
 import { getSorter } from "../sort";
-import { SortOption } from "../interfaces/interfaces";
+import { SortByNumberOption } from "../interfaces/interfaces";
 import { sortable, sortableWithOption } from "../types/types";
 
 /**
@@ -9,15 +9,88 @@ import { sortable, sortableWithOption } from "../types/types";
  * {@link https://sort-es.netlify.app/by-number byNumber docs}
  * @version 1.0.0
  */
-const byNumber: sortableWithOption<number, SortOption> = (
-  options: SortOption = { desc: false, nullable: false }
+const byNumber: sortableWithOption<number, SortByNumberOption> = (
+  options: SortByNumberOption = {
+    desc: false,
+    nullable: false,
+  }
 ): sortable<number> => {
-  const sorter = getSorter(options);
+  // Convert the options to primitive numbers in local variables.
+  const sign = getSorter(options)(1);
+  let signOfNaN: number;
+  switch (options.sortNaN) {
+    // The default setting is to sort NaN after any other value.  This is a
+    // change from the previous behavior, but any code that relied on the old
+    // behavior was almost certainly already broken anyway.  Before, the
+    // comparison function was inconsistent in the presence of NaN, and using it
+    // to sort an array containing NaN would therefore produce unspecified
+    // results according to the ECMAScript spec.  The new behavior at least
+    // produces a well-defined sort order.
+    //
+    // Why sort NaN after other values rather than before?  JavaScript's sorting
+    // algorithm always sorts undefined after any other value--it never even
+    // calls the comparison function with an undefined argument.  Since NaN is
+    // conceptually very simliar to undefined in a numeric context, the least
+    // surprising thing to do is to treat NaN similarly to undefined.
+    case undefined:
+    case "last":
+      signOfNaN = 1;
+      break;
+    case "first":
+      signOfNaN = -1;
+      break;
+    default:
+      signOfNaN = 0;
+  }
 
-  return (first: number, second: number): number =>
-    options.nullable
-      ? sorter((first || 0) - (second || 0))
-      : sorter(first - second);
+  // This is the basic comparison function used as-if unless `nullable` is set.
+  const compare = (first: number, second: number): number => {
+    // Start with a naive comparison.
+    const delta = first - second;
+
+    // This branch handles all cases except those involving NaN or infinites of
+    // the same sign.  We use the === operator to detect NaN because it's
+    // probably faster than calling Math.isNaN.
+    if (delta === delta) {
+      return sign * delta;
+    }
+
+    // This branch handles infinities with the same sign, as well as comparing
+    // undefined to itself.
+    if (first === second) {
+      return 0;
+    }
+
+    // At this point, either `first`, `second`, or both must be NaN or undefined.
+
+    // We use 0 as a sentinel value to signal that NaN should be treated as an
+    // error; undefined is not treated as an error because JavaScript's sorting
+    // algorithm has well-defined behavior for undefined.
+    if (signOfNaN === 0 && (first !== first || second !== second)) {
+      throw new Error(`Invalid comparison: ${first}, ${second}`);
+    }
+
+    // This comparison sorts undefined after all other values.  Depending on
+    // this `sortNaN` option, it sorts NaN before or after all other values
+    // (except undefined).  Note that the `desc` setting is intentionally
+    // ignored here.
+    return (
+      (first !== first ? signOfNaN : first === undefined ? 2 : 0) -
+      (second !== second ? signOfNaN : second === undefined ? 2 : 0)
+    );
+  };
+
+  // If requested, wrap the comparison function so it treats falsy values as
+  // equal to 0.  Despite the name, this option has no effect on the treatment
+  // of null, because ordinary subtraction treats null as equal to 0.  It also
+  // has no effect on how undefined is sorted by JavaScript's native sort
+  // algorithm, because undefined is always sorted last regardless of the
+  // comparison function.
+  if (options.nullable) {
+    return (first: number, second: number) => compare(first || 0, second || 0);
+  }
+
+  return compare;
 };
 
 export default byNumber;

--- a/test/byNumber.spec.ts
+++ b/test/byNumber.spec.ts
@@ -2,35 +2,176 @@ import "mocha";
 import { expect } from "chai";
 import { byNumber } from "../src/index";
 import { getFirstAndLast, reverse } from "./utils/sort";
-import { expectObjectToBeEquals } from "./utils/expectFns";
+import { expectStringToBeEquals } from "./utils/expectFns";
 
-const arrayUnsorted = [44, 12, 34, 124, 21.5];
-const correctArraySorted = [12, 21.5, 34, 44, 124];
+const finiteUnsorted = [44, 12, 34, 124, 21.5];
+const finiteSorted = [12, 21.5, 34, 44, 124];
+const nullableUnsorted = [null, 1, -1, null, 2, -2];
+const nullableSorted = [-2, -1, null, null, 1, 2];
+const infinitiesUnsorted = [
+  Infinity,
+  -Infinity,
+  Infinity,
+  -Infinity,
+  Infinity,
+  -Infinity,
+];
+const inifinitiesSorted = [
+  -Infinity,
+  -Infinity,
+  -Infinity,
+  Infinity,
+  Infinity,
+  Infinity,
+];
+const mixedUnsorted = [44, 12, 34, 0, NaN, Infinity, -Infinity, 124, 21.5, NaN];
+const mixedSortedNaNFirst = [
+  NaN,
+  NaN,
+  -Infinity,
+  0,
+  12,
+  21.5,
+  34,
+  44,
+  124,
+  Infinity,
+];
+const mixedSortedNaNLast = [
+  -Infinity,
+  0,
+  12,
+  21.5,
+  34,
+  44,
+  124,
+  Infinity,
+  NaN,
+  NaN,
+];
 
 describe("ByNumber sorting", () => {
-  it("Does sort an array by number", () => {
-    const arraySorted = arrayUnsorted.sort(byNumber());
-
+  it("Sorts an array by number", () => {
+    const arraySorted = finiteUnsorted.sort(byNumber());
     const [first, last] = getFirstAndLast(arraySorted);
-
     expect(first).to.equal(12);
-
     expect(last).to.equal(124);
-
-    expectObjectToBeEquals(arraySorted, correctArraySorted);
+    expectStringToBeEquals(arraySorted, finiteSorted);
   });
-});
 
-describe("ByNumber sorting desc", () => {
-  it("Does sort an array by string descending", () => {
-    const arraySorted = arrayUnsorted.sort(byNumber({ desc: true }));
-
+  it("Sorts an array by number descending", () => {
+    const arraySorted = finiteUnsorted.sort(byNumber({ desc: true }));
     const [first, last] = getFirstAndLast(arraySorted);
-
     expect(first).to.equal(124);
-
     expect(last).to.equal(12);
+    expectStringToBeEquals(arraySorted, reverse(finiteSorted));
+  });
+  it("Sorts nullable values", () => {
+    const arraySorted = nullableUnsorted.sort(byNumber({ nullable: true }));
+    const [first, last] = getFirstAndLast(arraySorted);
+    expect(first).to.equal(-2);
+    expect(last).to.equal(2);
+    expectStringToBeEquals(arraySorted, nullableSorted);
+  });
 
-    expectObjectToBeEquals(arraySorted, reverse(correctArraySorted));
+  it("Sorts nullable values descending", () => {
+    const arraySorted = nullableUnsorted.sort(
+      byNumber({ nullable: true, desc: true })
+    );
+    const [first, last] = getFirstAndLast(arraySorted);
+    expect(first).to.equal(2);
+    expect(last).to.equal(-2);
+    expectStringToBeEquals(arraySorted, reverse(nullableSorted));
+  });
+
+  it("Sorts infinities", () => {
+    const arraySorted = infinitiesUnsorted.sort(byNumber());
+    const [first, last] = getFirstAndLast(arraySorted);
+    expect(first).to.equal(-Infinity);
+    expect(last).to.equal(Infinity);
+    expectStringToBeEquals(arraySorted, inifinitiesSorted);
+  });
+
+  it("Sorts infinities descending", () => {
+    const arraySorted = infinitiesUnsorted.sort(byNumber({ desc: true }));
+    const [first, last] = getFirstAndLast(arraySorted);
+    expect(first).to.equal(Infinity);
+    expect(last).to.equal(-Infinity);
+    expectStringToBeEquals(arraySorted, reverse(inifinitiesSorted));
+  });
+
+  it("Sorts mixed types with NaN first", () => {
+    const arraySorted = mixedUnsorted.sort(byNumber({ sortNaN: "first" }));
+    expectStringToBeEquals(arraySorted, mixedSortedNaNFirst);
+  });
+
+  it("Sorts mixed types with NaN last", () => {
+    const arraySorted = mixedUnsorted.sort(byNumber({ sortNaN: "last" }));
+    expectStringToBeEquals(arraySorted, mixedSortedNaNLast);
+  });
+
+  it("Sorts mixed types descending with NaN first", () => {
+    const arraySorted = mixedUnsorted.sort(
+      byNumber({ sortNaN: "first", desc: true })
+    );
+    expectStringToBeEquals(arraySorted, reverse(mixedSortedNaNLast));
+  });
+
+  it("Sorts mixed types descending with NaN last", () => {
+    const arraySorted = mixedUnsorted.sort(
+      byNumber({ sortNaN: "last", desc: true })
+    );
+    expectStringToBeEquals(arraySorted, reverse(mixedSortedNaNFirst));
+  });
+
+  it("Throws an error on NaN", () => {
+    expect(() => byNumber({ sortNaN: "error" })(0, NaN)).throws();
+    expect(() => byNumber({ sortNaN: "error" })(NaN, 0)).throws();
+    expect(() => byNumber({ sortNaN: "error" })(NaN, NaN)).throws();
+  });
+
+  it("Does not throw an error on undefined", () => {
+    byNumber({ sortNaN: "error" })(0, undefined);
+    byNumber({ sortNaN: "error" })(undefined, 0);
+    byNumber({ sortNaN: "error" })(undefined, undefined);
+  });
+
+  // TODO
+  // it("Sorts undefined last", () => {
+  //   for (const compare of [byNumber(), byNumber({ desc: true })]) {
+  //     for (const defined of [NaN, -Infinity, 0, Infinity]) {
+  //       expect(compare(undefined, defined)).to.be.lessThan(0);
+  //       expect(compare(defined, undefined)).to.be.greaterThan(0);
+  //     }
+  //   }
+
+  //   const NaNFirstArray = [NaN, -Infinity, 0, Infinity, undefined];
+  //   const NaNLastArray = [-Infinity, 0, Infinity, NaN, undefined];
+  //   const NaNFirst = byNumber({ sortNaN: "first" });
+  //   const NaNLast = byNumber({ sortNaN: "last" });
+  //   const NaNDefault = byNumber();
+
+  //   for (let i = 1; i < NaNFirstArray.length; i++) {
+  //     expect(NaNFirst(NaNFirstArray[i - 1], NaNFirstArray[i])).to.be.lessThan(
+  //       0
+  //     );
+  //     expect(NaNLast(NaNLastArray[i - 1], NaNLastArray[i])).to.be.lessThan(0);
+  //     expect(NaNDefault(NaNLastArray[i - 1], NaNLastArray[i])).to.be.lessThan(
+  //       0
+  //     );
+  //     expect(
+  //       NaNFirst(NaNFirstArray[i], NaNFirstArray[i - 1])
+  //     ).to.be.greaterThan(0);
+  //     expect(NaNLast(NaNLastArray[i], NaNLastArray[i - 1])).to.be.greaterThan(
+  //       0
+  //     );
+  //     expect(
+  //       NaNDefault(NaNLastArray[i], NaNLastArray[i - 1])
+  //     ).to.be.greaterThan(0);
+  //   }
+  // });
+
+  it("Sorts many types of values", () => {
+    mixedSortedNaNFirst
   });
 });

--- a/test/byNumber.spec.ts
+++ b/test/byNumber.spec.ts
@@ -1,177 +1,84 @@
 import "mocha";
-import { expect } from "chai";
-import { byNumber } from "../src/index";
-import { getFirstAndLast, reverse } from "./utils/sort";
-import { expectStringToBeEquals } from "./utils/expectFns";
+import fc from "fast-check";
+import {
+  DEFAULT_NUMBER_VALUE_CATEGORY_ORDER,
+  NumberValueCategory,
+} from "../src/interfaces/interfaces";
+import byNumber, {
+  NumberLike,
+  normalizeNumberValueCategoryOrder,
+} from "../src/sortables/byNumber";
 
-const finiteUnsorted = [44, 12, 34, 124, 21.5];
-const finiteSorted = [12, 21.5, 34, 44, 124];
-const nullableUnsorted = [null, 1, -1, null, 2, -2];
-const nullableSorted = [-2, -1, null, null, 1, 2];
-const infinitiesUnsorted = [
-  Infinity,
-  -Infinity,
-  Infinity,
-  -Infinity,
-  Infinity,
-  -Infinity,
-];
-const inifinitiesSorted = [
-  -Infinity,
-  -Infinity,
-  -Infinity,
-  Infinity,
-  Infinity,
-  Infinity,
-];
-const mixedUnsorted = [44, 12, 34, 0, NaN, Infinity, -Infinity, 124, 21.5, NaN];
-const mixedSortedNaNFirst = [
-  NaN,
-  NaN,
-  -Infinity,
-  0,
-  12,
-  21.5,
-  34,
-  44,
-  124,
-  Infinity,
-];
-const mixedSortedNaNLast = [
-  -Infinity,
-  0,
-  12,
-  21.5,
-  34,
-  44,
-  124,
-  Infinity,
-  NaN,
-  NaN,
-];
+const arbSortable: fc.Arbitrary<NumberLike> = fc.oneof(
+  { weight: 10, arbitrary: fc.double() },
+  fc.constant(Infinity),
+  fc.constant(-Infinity),
+  fc.constant(NaN),
+  fc.constant(null),
+  fc.constant(undefined)
+);
+
+const arbCategoryOrder = fc.shuffledSubarray(
+  DEFAULT_NUMBER_VALUE_CATEGORY_ORDER.filter((cat) => cat !== "undefined")
+);
+
+function categoryOf(n: NumberLike): NumberValueCategory {
+  if (n === null) {
+    return "null";
+  }
+  if (n === undefined) {
+    return "undefined";
+  }
+  if (n !== n) {
+    return "NaN";
+  }
+  return "other";
+}
 
 describe("ByNumber sorting", () => {
-  it("Sorts an array by number", () => {
-    const arraySorted = finiteUnsorted.sort(byNumber());
-    const [first, last] = getFirstAndLast(arraySorted);
-    expect(first).to.equal(12);
-    expect(last).to.equal(124);
-    expectStringToBeEquals(arraySorted, finiteSorted);
-  });
-
-  it("Sorts an array by number descending", () => {
-    const arraySorted = finiteUnsorted.sort(byNumber({ desc: true }));
-    const [first, last] = getFirstAndLast(arraySorted);
-    expect(first).to.equal(124);
-    expect(last).to.equal(12);
-    expectStringToBeEquals(arraySorted, reverse(finiteSorted));
-  });
-  it("Sorts nullable values", () => {
-    const arraySorted = nullableUnsorted.sort(byNumber({ nullable: true }));
-    const [first, last] = getFirstAndLast(arraySorted);
-    expect(first).to.equal(-2);
-    expect(last).to.equal(2);
-    expectStringToBeEquals(arraySorted, nullableSorted);
-  });
-
-  it("Sorts nullable values descending", () => {
-    const arraySorted = nullableUnsorted.sort(
-      byNumber({ nullable: true, desc: true })
+  it("sorts numbers into the right categories", () => {
+    fc.assert(
+      fc.property(
+        fc.array(arbSortable),
+        arbCategoryOrder,
+        fc.boolean(),
+        (array, order, desc) => {
+          array.sort(byNumber({ valueCategoryOrder: order, desc }));
+          
+          let i = 0;
+          normalizeNumberValueCategoryOrder(order);
+          for (const category of order) {
+            while (i < array.length && categoryOf(array[i]) === category) {
+              i++;
+            }
+          }
+          return i === array.length;
+        }
+      ),
+      { numRuns: 10_000 }
     );
-    const [first, last] = getFirstAndLast(arraySorted);
-    expect(first).to.equal(2);
-    expect(last).to.equal(-2);
-    expectStringToBeEquals(arraySorted, reverse(nullableSorted));
   });
 
-  it("Sorts infinities", () => {
-    const arraySorted = infinitiesUnsorted.sort(byNumber());
-    const [first, last] = getFirstAndLast(arraySorted);
-    expect(first).to.equal(-Infinity);
-    expect(last).to.equal(Infinity);
-    expectStringToBeEquals(arraySorted, inifinitiesSorted);
-  });
-
-  it("Sorts infinities descending", () => {
-    const arraySorted = infinitiesUnsorted.sort(byNumber({ desc: true }));
-    const [first, last] = getFirstAndLast(arraySorted);
-    expect(first).to.equal(Infinity);
-    expect(last).to.equal(-Infinity);
-    expectStringToBeEquals(arraySorted, reverse(inifinitiesSorted));
-  });
-
-  it("Sorts mixed types with NaN first", () => {
-    const arraySorted = mixedUnsorted.sort(byNumber({ sortNaN: "first" }));
-    expectStringToBeEquals(arraySorted, mixedSortedNaNFirst);
-  });
-
-  it("Sorts mixed types with NaN last", () => {
-    const arraySorted = mixedUnsorted.sort(byNumber({ sortNaN: "last" }));
-    expectStringToBeEquals(arraySorted, mixedSortedNaNLast);
-  });
-
-  it("Sorts mixed types descending with NaN first", () => {
-    const arraySorted = mixedUnsorted.sort(
-      byNumber({ sortNaN: "first", desc: true })
+  it("sorts numbers correctly", () => {
+    fc.assert(
+      fc.property(
+        fc.array(arbSortable),
+        arbCategoryOrder,
+        fc.boolean(),
+        (array, order, desc) => {
+          array.sort(byNumber({ valueCategoryOrder: order, desc }));
+          
+          const sign = desc ? -1 : 1;
+          const justNumbers = array.filter((n) => categoryOf(n) === "other");
+          for (let i = 0; i < justNumbers.length - 1; i++) {
+            if (!(sign * justNumbers[i] <= sign * justNumbers[i + 1])) {
+              return false;
+            }
+          }
+          return true;
+        }
+      ),
+      { numRuns: 10_000 }
     );
-    expectStringToBeEquals(arraySorted, reverse(mixedSortedNaNLast));
-  });
-
-  it("Sorts mixed types descending with NaN last", () => {
-    const arraySorted = mixedUnsorted.sort(
-      byNumber({ sortNaN: "last", desc: true })
-    );
-    expectStringToBeEquals(arraySorted, reverse(mixedSortedNaNFirst));
-  });
-
-  it("Throws an error on NaN", () => {
-    expect(() => byNumber({ sortNaN: "error" })(0, NaN)).throws();
-    expect(() => byNumber({ sortNaN: "error" })(NaN, 0)).throws();
-    expect(() => byNumber({ sortNaN: "error" })(NaN, NaN)).throws();
-  });
-
-  it("Does not throw an error on undefined", () => {
-    byNumber({ sortNaN: "error" })(0, undefined);
-    byNumber({ sortNaN: "error" })(undefined, 0);
-    byNumber({ sortNaN: "error" })(undefined, undefined);
-  });
-
-  // TODO
-  // it("Sorts undefined last", () => {
-  //   for (const compare of [byNumber(), byNumber({ desc: true })]) {
-  //     for (const defined of [NaN, -Infinity, 0, Infinity]) {
-  //       expect(compare(undefined, defined)).to.be.lessThan(0);
-  //       expect(compare(defined, undefined)).to.be.greaterThan(0);
-  //     }
-  //   }
-
-  //   const NaNFirstArray = [NaN, -Infinity, 0, Infinity, undefined];
-  //   const NaNLastArray = [-Infinity, 0, Infinity, NaN, undefined];
-  //   const NaNFirst = byNumber({ sortNaN: "first" });
-  //   const NaNLast = byNumber({ sortNaN: "last" });
-  //   const NaNDefault = byNumber();
-
-  //   for (let i = 1; i < NaNFirstArray.length; i++) {
-  //     expect(NaNFirst(NaNFirstArray[i - 1], NaNFirstArray[i])).to.be.lessThan(
-  //       0
-  //     );
-  //     expect(NaNLast(NaNLastArray[i - 1], NaNLastArray[i])).to.be.lessThan(0);
-  //     expect(NaNDefault(NaNLastArray[i - 1], NaNLastArray[i])).to.be.lessThan(
-  //       0
-  //     );
-  //     expect(
-  //       NaNFirst(NaNFirstArray[i], NaNFirstArray[i - 1])
-  //     ).to.be.greaterThan(0);
-  //     expect(NaNLast(NaNLastArray[i], NaNLastArray[i - 1])).to.be.greaterThan(
-  //       0
-  //     );
-  //     expect(
-  //       NaNDefault(NaNLastArray[i], NaNLastArray[i - 1])
-  //     ).to.be.greaterThan(0);
-  //   }
-  // });
-
-  it("Sorts many types of values", () => {
-    mixedSortedNaNFirst
   });
 });

--- a/test/utils/expectFns.ts
+++ b/test/utils/expectFns.ts
@@ -1,8 +1,8 @@
 import "mocha";
-import {expect} from "chai";
-import {isSameDay} from "date-fns";
-import {withoutTime} from "./date";
-import {datable} from "../../src/types/types";
+import { expect } from "chai";
+import { isSameDay } from "date-fns";
+import { withoutTime } from "./date";
+import { datable } from "../../src/types/types";
 
 const expectObjectToBeEquals = <T>(item1: T, item2: T): void => {
   expect(JSON.stringify(item1)).to.be.equal(JSON.stringify(item2));
@@ -23,8 +23,21 @@ const expectDatableToBeEquals = (
   expectObjectToBeEquals(parsedArray1, parsedArray2);
 };
 
+// Doesn't handle objects, but handles infinities and NaN better than
+// `expectObjectToBeEquals`.
+const expectStringToBeEquals = (data1: unknown, data2: unknown): void => {
+  expect(String(data1)).to.be.equal(String(data2));
+};
+
+// TODO
+export const expectLessThan = <T>(item1: T, item2: T, cmp: (item1: T, item2: T) => number) => {
+  expect(cmp(item1, item2)).to.be.lessThan(0);
+  expect(cmp(item2, item1)).to.be.greaterThan(0);
+}
+
 export {
   expectObjectToBeEquals,
   expectDateToBeEquals,
   expectDatableToBeEquals,
+  expectStringToBeEquals,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1810,6 +1810,13 @@ execa@^7.1.1:
     signal-exit "^3.0.7"
     strip-final-newline "^3.0.0"
 
+fast-check@^3.13.1:
+  version "3.13.1"
+  resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/fast-check/-/fast-check-3.13.1.tgz#32c7a78621098bd30d71e40c0e269a728a3188e2"
+  integrity sha1-MsenhiEJi9MNceQMDiaacooxiOI=
+  dependencies:
+    pure-rand "^6.0.0"
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -3312,6 +3319,11 @@ punycode@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
   integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
+
+pure-rand@^6.0.0:
+  version "6.0.4"
+  resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/pure-rand/-/pure-rand-6.0.4.tgz#50b737f6a925468679bff00ad20eade53f37d5c7"
+  integrity sha1-ULc39qklRoZ5v/AK0g6t5T831cc=
 
 q@^1.5.1:
   version "1.5.1"


### PR DESCRIPTION
This PR adds a `valueCategoryOrder` field to the sort options for `byNumber` so the user can control exactly how `NaN`, `null`, and `undefined` values are sorted.